### PR TITLE
Make setup.py compatible with Python 3.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -254,7 +254,7 @@ bits, name = platform.architecture()
 arch = "x86"
 
 if "64" in bits:
-	arch = "AMD64"
+    arch = "AMD64"
 
 if not GetOption("help"):
 

--- a/setup.py
+++ b/setup.py
@@ -187,7 +187,7 @@ def process_nsound_h():
     print( fmt  % ('release', release))
 
     keys = d.keys()
-    keys.sort()
+    sorted(keys)
 
     for k in keys:
         print(fmt % (k, d[k]))


### PR DESCRIPTION
- Resolves #17 
- Use spaces consistently (I just threw that in).